### PR TITLE
Removed obsolete references to getSetting

### DIFF
--- a/R/run.R
+++ b/R/run.R
@@ -24,9 +24,9 @@
 #' @import futile.logger
 #' @import yaml
 #' @export
-run <- function(directory, ...) {
+run <- function(directory, logFile = NULL, ...) {
     futile.logger::flog.info("Starting sensorweby ...")
-    .configureLogging()
+    .configureLogging(file = logFile)
     # configure app
     futile.logger::flog.info("Starting sensorweby at %s", toString(directory))
     shiny::runApp(appDir = directory, ...)
@@ -60,12 +60,10 @@ runExample <- function(name) {
     return(x)
 }
 
-.configureLogging <- function() {
+.configureLogging <- function(file = NULL) {
     # configure logging
     futile.logger::flog.layout(futile.logger::layout.format("[~l] [~t] [~n.~f] ~m"))
-    futile.logger::flog.threshold(getLoglevelForName(getSetting("logging.level", "info")))
-    file <- getSetting("logging.file")
-    if( !is.null(file)) {
+    if(!is.null(file)) {
         futile.logger::flog.info("Logging to file %s with level %s", file,
                                  futile.logger::flog.logger()$threshold)
         futile.logger::flog.appender(futile.logger::appender.file(file = file))


### PR DESCRIPTION
As Olav reported:
```
 Error in gsub("^\\s+|\\s+$", "", x) : 
  could not find function "getSetting" In addition: Warning message:
In gsub("~f", the.function, message, fixed = TRUE) :
  argument 'replacement' has length > 1 and only the first element will be used
```